### PR TITLE
Remove Keymaps category

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"url": "https://github.com/prashantkoshta/tns-cli-vscode.git"
 	},
 	"categories": [
-		"Keymaps", "Languages", "Other"
+		"Languages", "Other"
 	],
     "engines": {
         "vscode": "^1.5.0"


### PR DESCRIPTION
Hi, thanks for building a cool extension! The purpose of the keymaps category is for extensions that provide a large set of keyboard shortcuts from another editor or IDE. Apologize our intention with the keymap category was not clearer. 